### PR TITLE
update PropTypes import

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -1,6 +1,7 @@
 # React & JSX
 snippet rrcc "React Redux Class Component" b
-import React, { Component, PropTypes } from 'react';
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styles from './${2:$1}.css';
 
@@ -32,7 +33,8 @@ export default connect(mapStateToProps)($1);
 endsnippet
 
 snippet rcc "React Class Component" b
-import React, { Component, PropTypes } from 'react';
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
 import styles from './${2:$1}.css';
 
 class ${1:`!v expand('%:t:r')`} extends Component {
@@ -58,7 +60,8 @@ export default $1;
 endsnippet
 
 snippet rfc "React Functional Component" b
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './${2:$1}.css';
 
 function ${1:`!v expand('%:t:r')`}(${3:{...props}}) {


### PR DESCRIPTION
Since react 15.5, `PropTypes` belong to the `prop-types` package