### PR TITLE
Fix functional component

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -64,7 +64,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './${2:$1}.css';
 
-function ${1:`!v expand('%:t:r')`}(${3:{...props}}) {
+function ${1:`!v expand('%:t:r')`}(${3:{...props}}) => {
 	return (
 		<div className={styles.base}>
 			$4

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -64,7 +64,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './${2:$1}.css';
 
-function ${1:`!v expand('%:t:r')`}(${3:{...props}}) => {
+const ${1:`!v expand('%:t:r')`} = (${3:{...props}}) => {
 	return (
 		<div className={styles.base}>
 			$4


### PR DESCRIPTION
```jsx
> 4 | const Icon = ({...props}) {
    |                           ^
  5 |     return (
  6 |         <div>
  7 |   
```
The snippet of functional component was missing the arrow.