### PR TITLE
class & functional components: Improved tabstops

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -39,8 +39,8 @@ import styles from './${2:$1}.css';
 
 class ${1:`!v expand('%:t:r')`} extends Component {
 	static propTypes = {
-		children: PropTypes.node,
-		className: PropTypes.string,
+		${2:children: PropTypes.node,
+		className: PropTypes.string,}
 	};
 
 	constructor(props) {
@@ -49,9 +49,9 @@ class ${1:`!v expand('%:t:r')`} extends Component {
 
 	render() {
 		return (
-			<div className={styles.base}>
-				$3
-			</div>
+			<${3:div} className={styles.base}>
+				$0
+			</$3>
 		);
 	}
 }
@@ -64,17 +64,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './${2:$1}.css';
 
-function ${1:`!v expand('%:t:r')`}(${3:{...props}}) {
+function ${1:`!v expand('%:t:r')`}({ $3 }) {
 	return (
-		<div className={styles.base}>
-			$4
-		</div>
+		<${5:div} className={styles.base}>
+			$0
+		</$5>
 	);
 }
 
-$1.defaultProps = {};
+$1.defaultProps = {$4};
 
-$1.propTypes = {};
+$1.propTypes = {`!p
+props = t[3]
+
+if props:
+  snip >> 1
+  for prop in props.split(', '):
+    snip += prop + ': PropTypes.any,'
+`
+};
 
 export default $1;
 endsnippet


### PR DESCRIPTION
This allows using the <kbd>ctrl</kbd>+<kbd>j</kbd> and <kbd>ctrl</kbd>+<kbd>k</kbd> shortcuts from UltiSnips to move forward and backward between tabstops. It also adds some cool python interpolation for the Functional component, which automatically adds the props specified in the function definition to the `PropTypes` definition at the bottom.

I wish I could figure out how to insert new tabstops within the interpolated python bit, but that will have to wait for another date (or contributor!).

## Class Component
![react class component](https://user-images.githubusercontent.com/221614/50987533-e2f8ef80-14d7-11e9-927f-dd775c1692de.gif)

## Functional Component
![react functional component](https://user-images.githubusercontent.com/221614/50987535-e3918600-14d7-11e9-908f-4a23fb42d9ab.gif)
